### PR TITLE
docker-compose: Ajustar serviço `db`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3.8"
 services:
   laravel:
     image: laravelfans/laravel:10.43.0
+    depends_on:
+      - db
     volumes:
         - ./:/var/www/laravel
     ports:
@@ -19,3 +21,4 @@ services:
       POSTGRES_DB: laravel
       POSTGRES_USER: root
       POSTGRES_PASSWORD: root
+      PGDATA: /var/lib/postgresql/data/pgdata


### PR DESCRIPTION
Atualmente, é necessário apagar a pasta `pgdata` antes de subir o container.

Esse PR também defini o serviço do Laravel para subir depois do banco de dados