### PR TITLE
adicionar responsividade na userhome

### DIFF
--- a/resources/views/pages/userhome.blade.php
+++ b/resources/views/pages/userhome.blade.php
@@ -2,7 +2,7 @@
 @section('content')
     @include('partials.main.nav')
     <div class="row mx-2 mb-auto">
-        <div class="col col-6">
+        <div class="col col-md-6 col-sm-12 mb-4">
             <ul class="list-group">
                 <li class="text-white list-group-item text-center">
                     <div class="d-flex justify-content-evenly">
@@ -39,7 +39,7 @@
                 @endif
             </ul>
         </div>
-        <div class="col col-6">
+        <div class="col col-md-6 col-sm-12 mb-4">
             <ul class="list-group">
                 <li class="text-white list-group-item text-center">
                     <div class="d-flex justify-content-evenly">


### PR DESCRIPTION
Fixes: #17

a página inicial do usuário logado não tinha ajustes de responsividade foi corrigido a estilização do bootstrap para melhorar a visualização em dispositivos móveis e telas pequenas.