### PR TITLE
arrumar visual do botão

### DIFF
--- a/resources/views/partials/main/nav.blade.php
+++ b/resources/views/partials/main/nav.blade.php
@@ -7,7 +7,7 @@
         </div>
 
         <div class="col-auto">
-            <span class=" shadow shadow-md btn-xs" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavMain"
+            <span class="shadow shadow-md btn-xs" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavMain"
                 aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <i class="bi bi-list fs-2"></i>
             </span>

--- a/resources/views/partials/task/tasks.blade.php
+++ b/resources/views/partials/task/tasks.blade.php
@@ -82,13 +82,14 @@
                         <td class="text-center align-middle py-0 my-0">
                             <nav class="navbar navbar-expand-lg navbar-dark bg-dark py-1 my-1">
                                 <div class="mx-auto">
-                                    <button class="navbar-toggler shadow shadow-md btn-sm" type="button"
-                                        data-bs-toggle="collapse" data-bs-target="#navbarNav-{{ $task['id'] }}"
-                                        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-                                        <span class="navbar-toggler-icon"></span>
-                                    </button>
+                                    <span class="shadow shadow-md btn-xs" type="button" data-bs-toggle="collapse"
+                                        data-bs-target="#navbarNav-{{ $task['id'] }}" aria-controls="navbarNav"
+                                        aria-expanded="false" aria-label="Toggle navigation">
+                                        <i class="bi bi-list fs-2"></i>
+                                    </span>
                                 </div>
-                                <div class="collapse navbar-collapse" id="navbarNav-{{ $task['id'] }}">
+
+                                <div class="collapse" id="navbarNav-{{ $task['id'] }}">
 
                                     {{-- add commentary button --}}
                                     <a class="btn btn-primary m-1 shadow shadow-md" title="Comentários"

--- a/resources/views/partials/tasklist/tasks.blade.php
+++ b/resources/views/partials/tasklist/tasks.blade.php
@@ -96,11 +96,11 @@
                         <td class="text-center align-middle py-0 my-0">
                             <nav class="navbar navbar-expand-lg navbar-dark bg-dark py-1 my-1">
                                 <div class="mx-auto">
-                                    <button class="navbar-toggler shadow shadow-md btn-sm" type="button"
-                                        data-bs-toggle="collapse" data-bs-target="#navbarNav-{{ $task['id'] }}"
-                                        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-                                        <span class="navbar-toggler-icon"></span>
-                                    </button>
+                                    <span class="shadow shadow-md btn-xs" type="button" data-bs-toggle="collapse"
+                                        data-bs-target="#navbarNav-{{ $task['id'] }}" aria-controls="navbarNav"
+                                        aria-expanded="false" aria-label="Toggle navigation">
+                                        <i class="bi bi-list fs-2"></i>
+                                    </span>
                                 </div>
                                 <div class="collapse navbar-collapse" id="navbarNav-{{ $task['id'] }}">
                                     {{-- commentary button --}}


### PR DESCRIPTION
Fixes: #23

o botão de menu hamburger não casava bem com o visual do projeto e ocupava um espaço desnecessário, foi corrigido usando um span ao invés de um button e usado o ícone do bootstrap: bi-list